### PR TITLE
reduce default websocket write buffer size from 2GiB to 32MiB

### DIFF
--- a/driveline/websocket/websocket.go
+++ b/driveline/websocket/websocket.go
@@ -48,7 +48,7 @@ const (
 	defaultReconnectWait    = 1 * time.Second
 	defaultMaxReconnectWait = defaultReconnectWait * maxReconnectWaitRatio
 
-	maxOutputBuffer = 2 * 1024 * 1024 * 1024
+	maxOutputBuffer = 32 * 1024 * 1024
 	readBufferSize  = 1024*1024 + 65536 + 1024
 	maxInputBuffer  = 16 * 1024 * 1024
 


### PR DESCRIPTION
I was seeing unexpectedly high client memory use with this;  lowering this buffer size significantly did not alter the performance in my tests.